### PR TITLE
Adding controller, creating end point, implementation for services, data classes, annotations for Jackson and insert swagger documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.postgresql:postgresql:42.7.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.2.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }

--- a/src/main/java/ru/yalrb/config/OpenApiConfig.java
+++ b/src/main/java/ru/yalrb/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package ru.yalrb.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Yalrb API")
+                        .description("Yalrb API end points")
+                        .version("0.1"));
+    }
+}

--- a/src/main/java/ru/yalrb/controller/AccountController.java
+++ b/src/main/java/ru/yalrb/controller/AccountController.java
@@ -1,0 +1,49 @@
+package ru.yalrb.controller;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.yalrb.model.Account;
+import ru.yalrb.service.AccountService;
+
+@RestController
+@RequestMapping("/account")
+public class AccountController {
+
+    @Autowired
+    AccountService accountService;
+
+    @Operation(summary = "Register a new user")
+    @PostMapping(value = "/registration",
+            consumes = "application/json",
+            produces = "application/json")
+    public Account addAccount(@io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "register a new user",
+            required = true,
+            content = @Content(
+                    schema = @Schema(
+                            example =
+                                    """
+                                            {
+                                                "id": null,
+                                                "role": null,
+                                                "level": null,
+                                                "login": "user123",
+                                                "password": "qwerty",
+                                                "phoneNumber": "+79999999999",
+                                                "createdDateTime": null
+                                            }
+                                            """)
+            )
+    )
+                              @JsonInclude(JsonInclude.Include.NON_NULL)
+                              @RequestBody Account account) {
+        return accountService.save(account);
+    }
+}

--- a/src/main/java/ru/yalrb/data/DataLevelType.java
+++ b/src/main/java/ru/yalrb/data/DataLevelType.java
@@ -1,0 +1,32 @@
+package ru.yalrb.data;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import ru.yalrb.model.LevelType;
+import ru.yalrb.service.LevelTypeService;
+
+@Component
+public class DataLevelType implements CommandLineRunner {
+
+    @Autowired
+    private LevelTypeService levelTypeService;
+    private LevelType stranger;
+    private LevelType god;
+
+    @Override
+    public void run(String... args) throws Exception {
+        stranger = LevelType.builder()
+                .name("Stranger")
+                .description("A newly registered user.")
+                .build();
+
+        god = LevelType.builder()
+                .name("God")
+                .description("The service administrator")
+                .build();
+
+        levelTypeService.save(stranger);
+        levelTypeService.save(god);
+    }
+}

--- a/src/main/java/ru/yalrb/data/DataRole.java
+++ b/src/main/java/ru/yalrb/data/DataRole.java
@@ -1,0 +1,33 @@
+package ru.yalrb.data;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import ru.yalrb.model.Role;
+import ru.yalrb.service.RoleService;
+
+@Component
+public class DataRole implements CommandLineRunner {
+
+    @Autowired
+    private RoleService roleService;
+
+    private Role user;
+    private Role admin;
+
+    @Override
+    public void run(String... args) throws Exception {
+        user = Role.builder()
+                .name("User")
+                .description("Common user")
+                .build();
+
+        admin = Role.builder()
+                .name("Admin")
+                .description("Admin privileges")
+                .build();
+
+        roleService.save(user);
+        roleService.save(admin);
+    }
+}

--- a/src/main/java/ru/yalrb/data/DataState.java
+++ b/src/main/java/ru/yalrb/data/DataState.java
@@ -1,0 +1,33 @@
+package ru.yalrb.data;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import ru.yalrb.model.State;
+import ru.yalrb.service.StateService;
+
+@Component
+public class DataState implements CommandLineRunner {
+
+    @Autowired
+    StateService stateService;
+
+    private State inOnline;
+    private State offline;
+
+    @Override
+    public void run(String... args) throws Exception {
+        inOnline = State.builder()
+                .name("In Online")
+                .description("user in online")
+                .build();
+
+        offline = State.builder()
+                .name("Offline")
+                .description("user offline")
+                .build();
+
+        stateService.save(inOnline);
+        stateService.save(offline);
+    }
+}

--- a/src/main/java/ru/yalrb/model/Account.java
+++ b/src/main/java/ru/yalrb/model/Account.java
@@ -1,5 +1,6 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,6 +20,9 @@ import java.util.UUID;
 @Entity
 @RequiredArgsConstructor
 @EqualsAndHashCode(exclude = {"feedbacks", "objects", "scores", "states"})
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -32,6 +36,7 @@ public class Account {
     @OneToOne(fetch = FetchType.EAGER,
             cascade = CascadeType.ALL)
     @JoinColumn(name = "level_guid")
+    @JsonManagedReference(value = "account-level")
     private Level level;
 
     @Column(nullable = false)
@@ -48,16 +53,19 @@ public class Account {
     @OneToMany(mappedBy = "account")
     @ToString.Exclude
     @Builder.Default
+    @JsonManagedReference(value = "account-feedbacks")
     private Set<Feedback> feedbacks = new HashSet<>();
 
     @OneToMany(mappedBy = "account")
     @ToString.Exclude
     @Builder.Default
+    @JsonManagedReference(value = "account-scores")
     private Set<Score> scores = new HashSet<>();
 
     @OneToMany(mappedBy = "account")
     @ToString.Exclude
     @Builder.Default
+    @JsonManagedReference(value = "account-objects")
     private Set<Object> objects = new HashSet<>();
 
     @ManyToMany(mappedBy = "accounts")

--- a/src/main/java/ru/yalrb/model/Feedback.java
+++ b/src/main/java/ru/yalrb/model/Feedback.java
@@ -1,5 +1,7 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +29,12 @@ public class Feedback {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "object_guid")
+    @JsonIgnore
     private Object object;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "account_guid")
+    @JsonBackReference(value = "account-feedbacks")
     private Account account;
 
     @Column(nullable = false)

--- a/src/main/java/ru/yalrb/model/Level.java
+++ b/src/main/java/ru/yalrb/model/Level.java
@@ -1,5 +1,6 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,11 +27,13 @@ public class Level {
     private UUID id;
 
     @OneToOne(mappedBy = "level")
+    @JsonBackReference(value = "account-level")
     private Account account;
 
     @ManyToOne(fetch = FetchType.EAGER,
             cascade = CascadeType.ALL)
     @JoinColumn(name = "level_type_guid")
+    @JsonBackReference(value = "level-type")
     private LevelType levelType;
 
     private int score;

--- a/src/main/java/ru/yalrb/model/LevelType.java
+++ b/src/main/java/ru/yalrb/model/LevelType.java
@@ -1,5 +1,6 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,5 +33,6 @@ public class LevelType {
     @ToString.Exclude
     @Builder.Default
     @OneToMany(mappedBy = "levelType")
+    @JsonManagedReference(value = "level-type")
     private Set<Level> levels = new HashSet<>();
 }

--- a/src/main/java/ru/yalrb/model/Object.java
+++ b/src/main/java/ru/yalrb/model/Object.java
@@ -1,5 +1,7 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,42 +31,50 @@ public class Object {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "account_guid")
+    @JsonBackReference(value = "account-objects")
     private Account account;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "type_guid")
+    @JsonIgnore
     private Type type;
 
 
     @ManyToOne(fetch = FetchType.EAGER,
             cascade = CascadeType.ALL)
     @JoinColumn(name = "contact_guid")
+    @JsonIgnore
     private Contact contact;
 
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "rate_guid")
+    @JsonIgnore
     private Rate rate;
 
     @OneToOne(fetch = FetchType.EAGER,
             cascade = CascadeType.ALL)
     @JoinColumn(name = "location_guid")
+    @JsonIgnore
     private Location location;
 
     @OneToMany(mappedBy = "object")
     @Builder.Default
     @ToString.Exclude
+    @JsonIgnore
     private Set<Feedback> feedbacks = new HashSet<>();
 
 
     @OneToMany(mappedBy = "object")
     @Builder.Default
     @ToString.Exclude
+    @JsonIgnore
     private Set<Photo> photos = new HashSet<>();
 
     @ManyToMany(mappedBy = "objects",
             cascade = CascadeType.MERGE)
     @Builder.Default
     @ToString.Exclude
+    @JsonIgnore
     private Set<State> states = new HashSet<>();
 
     @Column(nullable = false)

--- a/src/main/java/ru/yalrb/model/Role.java
+++ b/src/main/java/ru/yalrb/model/Role.java
@@ -1,5 +1,6 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,6 +18,9 @@ import java.util.UUID;
 @Entity
 @EqualsAndHashCode(exclude = "accounts")
 @RequiredArgsConstructor
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -32,5 +36,6 @@ public class Role {
     @OneToMany(mappedBy = "role")
     @ToString.Exclude
     @Builder.Default
+    @JsonIgnore
     private Set<Account> accounts = new HashSet<>();
 }

--- a/src/main/java/ru/yalrb/model/Score.java
+++ b/src/main/java/ru/yalrb/model/Score.java
@@ -1,5 +1,7 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,10 +27,12 @@ public class Score {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "account_guid")
+    @JsonBackReference(value = "account-scores")
     private Account account;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "feedback_guid")
+    @JsonIgnore
     private Feedback feedback;
 
     private int score;

--- a/src/main/java/ru/yalrb/model/State.java
+++ b/src/main/java/ru/yalrb/model/State.java
@@ -1,5 +1,6 @@
 package ru.yalrb.model;
 
+import com.fasterxml.jackson.annotation.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,6 +19,9 @@ import java.util.UUID;
 @Entity
 @RequiredArgsConstructor
 @EqualsAndHashCode(exclude = {"objects", "accounts"})
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class State {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -28,7 +32,7 @@ public class State {
     private String name;
 
     @Column(nullable = false)
-    private String Description;
+    private String description;
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "object_state",

--- a/src/main/java/ru/yalrb/service/implementation/AccountServiceImpl.java
+++ b/src/main/java/ru/yalrb/service/implementation/AccountServiceImpl.java
@@ -1,9 +1,17 @@
 package ru.yalrb.service.implementation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.yalrb.model.Account;
+import ru.yalrb.model.Level;
+import ru.yalrb.model.LevelType;
+import ru.yalrb.model.Role;
+import ru.yalrb.repository.AccountRepository;
 import ru.yalrb.service.AccountService;
+import ru.yalrb.service.LevelTypeService;
+import ru.yalrb.service.RoleService;
 
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,9 +20,36 @@ import java.util.UUID;
  */
 @Service
 public class AccountServiceImpl implements AccountService {
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    RoleService roleService;
+
+    @Autowired
+    LevelTypeService levelTypeService;
+
+    @Override
+    public Account update(UUID id) {
+        return null;
+    }
+
     @Override
     public Account save(Account entity) {
-        return null;
+        List<Role> roles = roleService.getAll();
+        Role role = roles.stream().filter(element -> element.getName().equals("User")).toList().getFirst();
+        List<LevelType> levelTypes = levelTypeService.getAll();
+        LevelType levelType = levelTypes.stream().filter(type -> type.getName().equals("Stranger")).toList().getFirst();
+        Level level = Level.builder()
+                .score(0)
+                .levelType(levelType)
+                .build();
+        entity.setLevel(level);
+        entity.setCreatedDateTime(new Date());
+        entity.setRole(role);
+
+        return accountRepository.save(entity);
     }
 
     @Override
@@ -27,10 +62,6 @@ public class AccountServiceImpl implements AccountService {
         return null;
     }
 
-    @Override
-    public Account update(UUID id) {
-        return null;
-    }
 
     @Override
     public void delete(UUID id) {

--- a/src/main/java/ru/yalrb/service/implementation/LevelTypeServiceImpl.java
+++ b/src/main/java/ru/yalrb/service/implementation/LevelTypeServiceImpl.java
@@ -1,10 +1,13 @@
 package ru.yalrb.service.implementation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.yalrb.model.LevelType;
+import ru.yalrb.repository.LevelTypeRepository;
 import ru.yalrb.service.LevelTypeService;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -12,20 +15,9 @@ import java.util.UUID;
  */
 @Service
 public class LevelTypeServiceImpl implements LevelTypeService {
-    @Override
-    public LevelType save(LevelType entity) {
-        return null;
-    }
 
-    @Override
-    public LevelType getById(UUID id) {
-        return null;
-    }
-
-    @Override
-    public List<LevelType> getAll() {
-        return null;
-    }
+    @Autowired
+    LevelTypeRepository levelTypeRepository;
 
     @Override
     public LevelType update(UUID id) {
@@ -33,7 +25,23 @@ public class LevelTypeServiceImpl implements LevelTypeService {
     }
 
     @Override
-    public void delete(UUID id) {
+    public LevelType save(LevelType entity) {
+        return levelTypeRepository.save(entity);
+    }
 
+    @Override
+    public LevelType getById(UUID id) {
+        Optional<LevelType> levelType = levelTypeRepository.findById(id);
+        return levelType.orElseGet(LevelType::new);
+    }
+
+    @Override
+    public List<LevelType> getAll() {
+        return levelTypeRepository.findAll();
+    }
+
+    @Override
+    public void delete(UUID id) {
+        levelTypeRepository.deleteById(id);
     }
 }

--- a/src/main/java/ru/yalrb/service/implementation/RoleServiceImpl.java
+++ b/src/main/java/ru/yalrb/service/implementation/RoleServiceImpl.java
@@ -1,10 +1,13 @@
 package ru.yalrb.service.implementation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.yalrb.model.Role;
+import ru.yalrb.repository.RoleRepository;
 import ru.yalrb.service.RoleService;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -12,19 +15,13 @@ import java.util.UUID;
  */
 @Service
 public class RoleServiceImpl implements RoleService {
+
+    @Autowired
+    RoleRepository roleRepository;
+
     @Override
     public Role save(Role entity) {
-        return null;
-    }
-
-    @Override
-    public Role getById(UUID id) {
-        return null;
-    }
-
-    @Override
-    public List<Role> getAll() {
-        return null;
+        return roleRepository.save(entity);
     }
 
     @Override
@@ -33,7 +30,18 @@ public class RoleServiceImpl implements RoleService {
     }
 
     @Override
-    public void delete(UUID id) {
+    public Role getById(UUID id) {
+        Optional<Role> role = roleRepository.findById(id);
+        return role.orElseGet(Role::new);
+    }
 
+    @Override
+    public List<Role> getAll() {
+        return roleRepository.findAll();
+    }
+
+    @Override
+    public void delete(UUID id) {
+        roleRepository.deleteById(id);
     }
 }

--- a/src/main/java/ru/yalrb/service/implementation/StateServiceImpl.java
+++ b/src/main/java/ru/yalrb/service/implementation/StateServiceImpl.java
@@ -1,10 +1,13 @@
 package ru.yalrb.service.implementation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.yalrb.model.State;
+import ru.yalrb.repository.StateRepository;
 import ru.yalrb.service.StateService;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -12,19 +15,13 @@ import java.util.UUID;
  */
 @Service
 public class StateServiceImpl implements StateService {
+
+    @Autowired
+    StateRepository stateRepository;
+
     @Override
     public State save(State entity) {
-        return null;
-    }
-
-    @Override
-    public State getById(UUID id) {
-        return null;
-    }
-
-    @Override
-    public List<State> getAll() {
-        return null;
+        return stateRepository.save(entity);
     }
 
     @Override
@@ -33,7 +30,18 @@ public class StateServiceImpl implements StateService {
     }
 
     @Override
-    public void delete(UUID id) {
+    public State getById(UUID id) {
+        Optional<State> state = stateRepository.findById(id);
+        return state.orElseGet(State::new);
+    }
 
+    @Override
+    public List<State> getAll() {
+        return stateRepository.findAll();
+    }
+
+    @Override
+    public void delete(UUID id) {
+        stateRepository.deleteById(id);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true

--- a/src/test/java/ru/yalrb/EntityRelationshipTests.java
+++ b/src/test/java/ru/yalrb/EntityRelationshipTests.java
@@ -110,17 +110,17 @@ public class EntityRelationshipTests {
 
         stateRegistry = State.builder()
                 .name("Registry")
-                .Description("test")
+                .description("test")
                 .build();
 
         stateConfirm = State.builder()
                 .name("Confirm")
-                .Description("Test")
+                .description("Test")
                 .build();
 
         stateWork = State.builder()
                 .name("Work")
-                .Description("Test")
+                .description("Test")
                 .build();
 
         object = Object.builder()


### PR DESCRIPTION
In this push:

- Adding swagger for end point documentation
- Creating controller on one end point for registration account
- Adding data classes for init database initial data
- Adding Jackson annotations for JSON format and to avoid infinite recursion in sets
- Adding implementation for services
- Adding application properties
- Adding dependencies for web 